### PR TITLE
fix for (null) at the end of the signing key

### DIFF
--- a/OAuthCore.h
+++ b/OAuthCore.h
@@ -7,10 +7,19 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSString *OAuthorizationHeader(NSURL *url, 
+extern NSString *OAuthorizationHeader(NSURL *url,
 									  NSString *method, 
 									  NSData *body, 
 									  NSString *_oAuthConsumerKey, 
 									  NSString *_oAuthConsumerSecret, 
 									  NSString *_oAuthToken, 
 									  NSString *_oAuthTokenSecret);
+
+extern NSString *OAuthorizationHeaderWithCallback(NSURL *url,
+                                                  NSString *method,
+                                                  NSData *body,
+                                                  NSString *_oAuthConsumerKey,
+                                                  NSString *_oAuthConsumerSecret,
+                                                  NSString *_oAuthToken,
+                                                  NSString *_oAuthTokenSecret,
+                                                  NSString *_oAuthCallback);

--- a/OAuthCore.m
+++ b/OAuthCore.m
@@ -87,7 +87,7 @@ NSString *OAuthorizationHeader(NSURL *url, NSString *method, NSData *body, NSStr
 	
 	NSString *key = [NSString stringWithFormat:@"%@&%@",
 					 [_oAuthConsumerSecret ab_RFC3986EncodedString],
-					 [_oAuthTokenSecret ab_RFC3986EncodedString]];
+					 [_oAuthTokenSecret ab_RFC3986EncodedString] ?: @""];
 	
 	NSData *signature = HMAC_SHA1(signatureBaseString, key);
 	NSString *base64Signature = [signature base64EncodedString];

--- a/OAuthCore.m
+++ b/OAuthCore.m
@@ -27,7 +27,11 @@ static NSData *HMAC_SHA1(NSString *data, NSString *key) {
 	return [NSData dataWithBytes:buf length:CC_SHA1_DIGEST_LENGTH];
 }
 
-NSString *OAuthorizationHeader(NSURL *url, NSString *method, NSData *body, NSString *_oAuthConsumerKey, NSString *_oAuthConsumerSecret, NSString *_oAuthToken, NSString *_oAuthTokenSecret)
+NSString *OAuthorizationHeader(NSURL *url, NSString *method, NSData *body, NSString *_oAuthConsumerKey, NSString *_oAuthConsumerSecret, NSString *_oAuthToken, NSString *_oAuthTokenSecret) {
+  return OAuthorizationHeaderWithCallback(url, method, body, _oAuthConsumerKey, _oAuthConsumerSecret, _oAuthToken, _oAuthTokenSecret, nil);
+}
+
+NSString *OAuthorizationHeaderWithCallback(NSURL *url, NSString *method, NSData *body, NSString *_oAuthConsumerKey, NSString *_oAuthConsumerSecret, NSString *_oAuthToken, NSString *_oAuthTokenSecret, NSString *_oAuthCallback)
 {
 	NSString *_oAuthNonce = [NSString ab_GUID];
 	NSString *_oAuthTimestamp = [NSString stringWithFormat:@"%d", (int)[[NSDate date] timeIntervalSince1970]];
@@ -42,7 +46,9 @@ NSString *OAuthorizationHeader(NSURL *url, NSString *method, NSData *body, NSStr
 	[oAuthAuthorizationParameters setObject:_oAuthConsumerKey forKey:@"oauth_consumer_key"];
 	if(_oAuthToken)
 		[oAuthAuthorizationParameters setObject:_oAuthToken forKey:@"oauth_token"];
-	
+	if (_oAuthCallback)
+		[oAuthAuthorizationParameters setObject:_oAuthCallback forKey:@"oauth_callback"];
+
 	// get query and body parameters
 	NSDictionary *additionalQueryParameters = [NSURL ab_parseURLQueryString:[url query]];
 	NSDictionary *additionalBodyParameters = nil;


### PR DESCRIPTION
Here is a fix for scenarios in which there is no auth token secret. For instance in step 1 of reverse auth. Prior to this fix the signing key had '(null)' appended to the end and the signature was invalid every time.

All this fix does is use the empty string for the auth token secret when one exists, instead of using '(null)'.

Thanks!
Andrew
