### PR TITLE
Preserve trailing slash in signature base

### DIFF
--- a/OAuth+Additions.h
+++ b/OAuth+Additions.h
@@ -10,6 +10,7 @@
 @interface NSURL (OAuthAdditions)
 
 + (NSDictionary *)ab_parseURLQueryString:(NSString *)query;
+- (NSString *)ab_actualPath;
 
 @end
 

--- a/OAuth+Additions.m
+++ b/OAuth+Additions.m
@@ -28,18 +28,8 @@
 
 - (NSString *)ab_actualPath
 {
-    NSString *urlString = [self absoluteString];
-    
-    NSRange range = [urlString rangeOfString:@"?"];
-    if (range.location != NSNotFound) {
-        urlString = [urlString substringToIndex:range.location];
-    }
-    
-    if ([urlString hasSuffix:@"/"]) {
-        return [NSString stringWithFormat:@"%@/", [self path]];
-    }
-    
-    return [self path];
+    NSString* cfPath = [(NSString*)CFURLCopyPath((CFURLRef)self) autorelease];
+    return cfPath;
 }
 
 @end

--- a/OAuth+Additions.m
+++ b/OAuth+Additions.m
@@ -26,6 +26,22 @@
 	return [NSDictionary dictionaryWithDictionary:dict];
 }
 
+- (NSString *)ab_actualPath
+{
+    NSString *urlString = [self absoluteString];
+    
+    NSRange range = [urlString rangeOfString:@"?"];
+    if (range.location != NSNotFound) {
+        urlString = [urlString substringToIndex:range.location];
+    }
+    
+    if ([urlString hasSuffix:@"/"]) {
+        return [NSString stringWithFormat:@"%@/", [self path]];
+    }
+    
+    return [self path];
+}
+
 @end
 
 @implementation NSString (OAuthAdditions)

--- a/OAuthCore.m
+++ b/OAuthCore.m
@@ -80,9 +80,9 @@ NSString *OAuthorizationHeaderWithCallback(NSURL *url, NSString *method, NSData 
 	
 	NSString *normalizedURLString;
 	if([url port] == nil) {
-		normalizedURLString = [NSString stringWithFormat:@"%@://%@%@", [url scheme], [url host], [url path]];
+		normalizedURLString = [NSString stringWithFormat:@"%@://%@%@", [url scheme], [url host], [url ab_actualPath]];
 	} else {
-		normalizedURLString = [NSString stringWithFormat:@"%@://%@:%@%@", [url scheme], [url host], [url port], [url path]];
+		normalizedURLString = [NSString stringWithFormat:@"%@://%@:%@%@", [url scheme], [url host], [url port], [url ab_actualPath]];
 	}
 	
 	NSString *signatureBaseString = [NSString stringWithFormat:@"%@&%@&%@",


### PR DESCRIPTION
This patch changes the library to preserve the trailing slash when computing
the signature base string.

-[NSURL path] function always excludes a trailing slash. Since the oauth specification
makes no mention of excluding a trailing slash, it seems correct to preserve it. At least
one python server-side library will not accept requests without this patch.
